### PR TITLE
Fix typo 'fasle' to 'false' in 'extend.md'

### DIFF
--- a/docs/guide/extend.md
+++ b/docs/guide/extend.md
@@ -34,7 +34,7 @@ dns:
 
 # 订阅C
 dns:
-  enable: fasle
+  enable: false
 find-process-mode: strict
 
 ```


### PR DESCRIPTION
This PR fixes a typo in the guide for using clash verge rev, where 'fasle' was incorrectly used instead of 'false'. No other changes were made.