### PR TITLE
update: synchronize the arch linux package database before installing packages

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -70,7 +70,7 @@
     
                 ```bash
                 sudo pacman-key --lsign-key "farseerfc@archlinux.org"
-                sudo pacman -S archlinuxcn-keyring
+                sudo pacman -Sy archlinuxcn-keyring
                 sudo pacman -S paru
                 ```
     
@@ -97,7 +97,7 @@
     
                 ```bash
                 sudo pacman-key --lsign-key "farseerfc@archlinux.org"
-                sudo pacman -S archlinuxcn-keyring
+                sudo pacman -Sy archlinuxcn-keyring
                 sudo pacman -S yay
                 ```
     


### PR DESCRIPTION
Failure to synchronize the package database will result in packages such as `archlinuxcn-keyring` not being installed.